### PR TITLE
Changing regExp with broader validation

### DIFF
--- a/solution/app/sw.js
+++ b/solution/app/sw.js
@@ -40,7 +40,7 @@ if (workbox) {
   });
 
   workbox.routing.registerRoute(
-    /\/api\/add/,
+    ({url}) => url.pathname === "/api/add",
     networkWithBackgroundSync,
     'POST'
   );


### PR DESCRIPTION
I was having problems with the url validation using the RegExp (using c9.io). I changed the url rule to focus on the pathname and it worked. I thought you might be interested in this small fix.

Great job!